### PR TITLE
Fix code scanning alert no. 6: Prototype-polluting assignment

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -2682,7 +2682,7 @@ d-citation-list .references .title {
         highlight: function (text, grammar, language) {
           var env = {
             code: text,
-            grammar: grammar,
+            grammar: new Map(Object.entries(grammar)),
             language: language,
           };
           _.hooks.run("before-tokenize", env);
@@ -2692,13 +2692,13 @@ d-citation-list .references .title {
         },
 
         tokenize: function (text, grammar) {
-          var rest = grammar.rest;
+          var rest = grammar.get('rest');
           if (rest) {
-            for (var token in rest) {
-              grammar[token] = rest[token];
+            for (var token of rest.keys()) {
+              grammar.set(token, rest.get(token));
             }
 
-            delete grammar.rest;
+            grammar.delete('rest');
           }
 
           var tokenList = new LinkedList();
@@ -3019,7 +3019,7 @@ d-citation-list .references .title {
                 code = message.code,
                 immediateClose = message.immediateClose;
 
-              _self.postMessage(_.highlight(code, _.languages[lang], lang));
+              _self.postMessage(_.highlight(code, _.languages.get(lang), lang));
               if (immediateClose) {
                 _self.close();
               }


### PR DESCRIPTION
Fixes [https://github.com/paraskevasleivadaros/al-folio/security/code-scanning/6](https://github.com/paraskevasleivadaros/al-folio/security/code-scanning/6)

To fix the prototype pollution vulnerability, we need to ensure that the `grammar` object is not modified using untrusted keys that could lead to prototype pollution. One effective way to achieve this is by using a `Map` object instead of a plain JavaScript object for `grammar`. `Map` objects do not have the same prototype properties as plain objects, making them resilient to prototype pollution.

We will:
1. Replace the `grammar` object with a `Map` object.
2. Update the code to use `Map` methods (`set` and `get`) for accessing and modifying `grammar`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
